### PR TITLE
explicitly define platform version as espilight fails to link with newer

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 default_envs = d1_mini
 
 [env:d1_mini]
-platform = espressif8266
+platform = espressif8266@2.6.3
 board = d1_mini
 framework = arduino
 lib_deps = rc-switch@^2.6.3


### PR DESCRIPTION
I spent about an hour to find out why i'm unable to build it. It seems there is something in ESPilight lib that makes it incompatible with newer espessif8266 platform. Could be useful. 